### PR TITLE
Consolidating configs; updating photon recommendations

### DIFF
--- a/Root/dijetISR_DAODtoMT.cxx
+++ b/Root/dijetISR_DAODtoMT.cxx
@@ -119,7 +119,7 @@ EL::StatusCode dijetISR_DAODtoMT::execute() {
 EL::StatusCode dijetISR_DAODtoMT::executeSingle(const std::string& systName, const SystType& systType) {
 
     // Make sure the output tree exists for the current systematic
-  if (m_trees.count(s_treeName(systName, systType)) == 0) { addTree(s_treeName(systName, systType)); }
+    if (m_trees.count(s_treeName(systName, systType)) == 0) { addTree(s_treeName(systName, systType)); }
 
      // Retrieve containers
     // -------------------------------------------------------------------------

--- a/scripts/config_DAODtoMT_common.py
+++ b/scripts/config_DAODtoMT_common.py
@@ -59,7 +59,7 @@ def get_defaults(args):
                                         "m_applyPrimaryVertexCut" : True,
                                         "m_applyEventCleaningCut" : True,
                                         "m_applyCoreFlagsCut"     : True,
-                                        #"m_triggerSelection"      : triggers,
+                                        #"m_triggerSelection"      : triggers, # Channel-specific
                                         "m_storeTrigDecisions"    : True,
                                         "m_applyTriggerCut"       : False,
                                         "m_useMetaData"           : True,
@@ -85,12 +85,14 @@ def get_defaults(args):
                                      "m_calibSequence"         : "EtaJES_JMS",
                                      "m_JESUncertConfig"       : "UJ_2016/Moriond2017/UJ2016_CombinedMass_medium.config",
                                      "m_JESUncertMCType"       : "MC15c",
+                                     #"m_JERUncertConfig"       : "...",
+                                     #"m_JERFullSys"            : True, 
                                      "m_setAFII"               : False,
                                      "m_systName"              : systName,
                                      "m_systVal"               : systVal,
                                      }
     
-    # Large-radius jet selection
+    # Large-radius jet selector
     defaults["FatJetSelector"] = { "m_name"                    : "FatJetSelector",
                                    "m_inContainerName"         : "CalibFatJets",
                                    "m_inputAlgo"               : "AntiKt10LCTopoTrimmedPtFrac5SmallR20_Calib_Algo",
@@ -124,8 +126,8 @@ def get_defaults(args):
                                   "m_JESUncertConfig"       : "JES_2016/Moriond2017/JES2016_SR_Scenario1.config",
                                   "m_JESUncertMCType"       : "MC15",
                                   "m_JERUncertConfig"       : "JetResolution/Prerec2015_xCalib_2012JER_ReducedTo9NP_Plots_v2.root",
-                                  "m_JERFullSys"            : False,
-                                  "m_JERApplyNominal"       : False,
+                                  "m_JERFullSys"            : False, # @TODO: Do JER?
+                                  "m_JERApplyNominal"       : False, # @TODO: Do JER?
                                   "m_redoJVT"               : False,
                                   "m_systName"              : systName,
                                   "m_systVal"               : systVal,
@@ -156,8 +158,8 @@ def get_defaults(args):
                                      "m_inContainerName"         : "Photons",
                                      "m_outContainerName"        : "CalibPhotons",
                                      "m_outputAlgoSystNames"     : "Photons_Calib_Algo",
-                                     "m_esModel"                 : "es2015cPRE", # @TODO: Update
-                                     "m_decorrelationModel"      : "1NP_v1", # @TODO: Update
+                                     "m_esModel"                 : "es2016data_mc15c", # [1]
+                                     "m_decorrelationModel"      : "1NP_v1", # or "FULL_ETACORRELATED_v1" # [2,3]
                                      "m_useAFII"                 : False,
                                      "m_systName"                : systName,
                                      "m_systVal"                 : systVal,
@@ -171,7 +173,7 @@ def get_defaults(args):
                                    "m_inputAlgoSystNames"      : "Photons_Calib_Algo",
                                    "m_outContainerName"        : "SelPhotons",
                                    "m_outputAlgoSystNames"     : "SelPhotons_Algo",
-                                   "m_decorateSelectedObjects" : False,
+                                   "m_decorateSelectedObjects" : True,
                                    "m_createSelectedContainer" : True,
                                    "m_pass_min"                : 0,
                                    "m_pT_min"                  : 100e3,
@@ -179,21 +181,29 @@ def get_defaults(args):
                                    "m_vetoCrack"               : True,
                                    "m_doAuthorCut"             : True,
                                    "m_doOQCut"                 : True,
-                                   "m_photonIdCut"             : "Tight", # @TODO: Want to propagate 'Loose' as well?
-                                   "m_MinIsoWPCut"             : "FixedCutTightCaloOnly"
+                                   "m_photonIdCut"             : "Loose", #  or "Tight"
+                                   "m_MinIsoWPCut"             : "FixedCutLoose" # or "FixedCutTightCaloOnly" # [4]
                                    }
     
     # Dijet + ISR analysis algorithm
     defaults["dijetISR_DAODtoMT"] = { "m_doJets"               : False,
                                       "m_doPhotons"            : False,
                                       "m_fatJetContainerName"  : "SelFatJets",
-                                      #"m_jetContainerName"    : "SelJets", # @TODO: Just keep both in?
-                                      #"m_photonContainerName" : "SelPhotons",
+                                      "m_jetContainerName"     : "SelJets",
+                                      "m_photonContainerName"  : "SelPhotons",
                                       "m_eventInfoDetailStr"   : "pileup truth",
                                       "m_trigDetailStr"        : "passTriggers",
                                       "m_fatJetDetailStr"      : "kinematic substructure",
-                                      #"m_jetDetailStr"         : "kinematic", # @TODO: Just keep both in?
-                                      #"m_photonDetailStr"      : "kinematic",
+                                      "m_jetDetailStr"         : "kinematic", 
+                                      "m_photonDetailStr"      : "kinematic isolation PID effSF", # purity
                                       }
     # Return
     return defaults
+
+
+# References:
+# --------------------------------------
+# [1] https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/ElectronPhotonFourMomentumCorrection#Recommendations_for_data15_data1
+# [2] https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/ElectronPhotonFourMomentumCorrection#New_correlation_model_to_combine
+# [3] https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/ElectronPhotonFourMomentumCorrection#Configuration_properties
+# [4] https://twiki.cern.ch/twiki/bin/view/AtlasProtected/IsolationSelectionTool#Photons

--- a/scripts/config_DAODtoMT_jet.py
+++ b/scripts/config_DAODtoMT_jet.py
@@ -1,9 +1,15 @@
 from xAH_config import xAH_config
 
-# basic xAH configuration
-c = xAH_config()
+# Script is called from xAODAnaHelpers/scripts/, and dijetISR/scripts/ is not (necessarily) in PYTHONPATH, so set manually
+import os, sys, inspect
+pwd = os.path.dirname(os.path.abspath(inspect.stack()[0][1]))
+sys.path.append(pwd)
 
-# single jet triggers
+# Get default algorithm configurations
+from config_DAODtoMT_common import get_defaults
+defaults = get_defaults(args)
+
+# Single jet triggers
 triggersList = [
     "HLT_j340",
     "HLT_j380",
@@ -19,134 +25,27 @@ triggersList = [
 ]
 triggers = ",".join(triggersList)
 
-# get derivation from file list name (default is EXOT18)
-deriv = ''
-if args.use_inputFileList:
-    inputstring = str.split((args.input_filename)[0], ".")
-    deriv = inputstring[-2]
-    deriv += "Kernel"
-    if ("JETM" not in deriv and "EXOT" not in deriv):
-        raise Exception("Invalid file list name!  Must be of form <name>.<derivation>.list")
-else:
-    inputstring = str.split((args.input_filename)[0], "/")
-    dname = str.split(inputstring[-1], ".")
-    dname1 = str.split(dname[0], "_")
-    if "DAOD" in dname1[0]:
-        deriv = dname1[1] + "Kernel"
-    else:
-        deriv = 'EXOT18Kernel'
+# xAODAnaHelper algorithm configuration
+c = xAH_config()
 
-# small-R jet sequence
-if args.is_MC:
-    jet_calibSeq = 'JetArea_Residual_Origin_EtaJES_GSC'
-else:
-    jet_calibSeq = 'JetArea_Residual_Origin_EtaJES_GSC_Insitu'
+# Basic event selection
+BasicEventSelection = defaults["BasicEventSelection"]
+BasicEventSelection["m_triggerSelection"] = triggers
+c.setalg("BasicEventSelection", BasicEventSelection)
 
-# basic event selection
-c.setalg("BasicEventSelection", { "m_name"                  : "BasicEventSelection",
-                                  "m_debug"                 : False,
-                                  "m_derivationName"        : deriv,
-                                  "m_applyGRLCut"           : False,
-                                  "m_doPUreweighting"       : False,
-                                  "m_vertexContainerName"   : "PrimaryVertices",
-                                  "m_PVNTrack"              : 2,
-                                  "m_applyPrimaryVertexCut" : True,
-                                  "m_applyEventCleaningCut" : True,
-                                  "m_applyCoreFlagsCut"     : True,
-                                  "m_triggerSelection"      : triggers,
-                                  "m_storeTrigDecisions"    : True,
-                                  "m_applyTriggerCut"       : False,
-                                  "m_useMetaData"           : True
-                                } )
+# Large-radius jet calibrator
+c.setalg("JetCalibrator", defaults["FatJetCalibrator"])
 
-# fat jet calibrator
-c.setalg("JetCalibrator", { "m_name"                  : "FatJetCalibrator",
-                            "m_inContainerName"       : "AntiKt10LCTopoTrimmedPtFrac5SmallR20Jets",
-                            "m_jetAlgo"               : "AntiKt10LCTopoTrimmedPtFrac5SmallR20",
-                            "m_outContainerName"      : "CalibFatJets",
-                            "m_outputAlgo"            : "AntiKt10LCTopoTrimmedPtFrac5SmallR20_Calib_Algo",
-                            "m_debug"                 : False,
-                            "m_verbose"               : False,
-                            "m_sort"                  : True,
-                            "m_saveAllCleanDecisions" : True,
-                            "m_jetCleanCutLevel"      : "LooseBad",
-                            "m_jetCleanUgly"          : True,
-                            "m_cleanParent"           : True,
-                            "m_applyFatJetPreSel"     : True,
-                            "m_calibConfigFullSim"    : "JES_MC15recommendation_FatJet_Nov2016_QCDCombinationUncorrelatedWeights.config",
-                            "m_calibConfigData"       : "JES_MC15recommendation_FatJet_Nov2016_QCDCombinationUncorrelatedWeights.config",
-                            "m_calibSequence"         : "EtaJES_JMS",
-                            "m_JESUncertConfig"       : "UJ_2016/Moriond2017/UJ2016_CombinedMass_medium.config",
-                            "m_JESUncertMCType"       : "MC15c",
-                            "m_setAFII"               : False,
-                            "m_systName"              : "All",
-                            "m_systVal"               : 1
-                          } )
+# Large-radius jet selector
+c.setalg("JetSelector", defaults["FatJetSelector"])
 
-c.setalg("JetSelector", { "m_name"                    : "FatJetSelector",
-                          "m_inContainerName"         : "CalibFatJets",
-                          "m_inputAlgo"               : "AntiKt10LCTopoTrimmedPtFrac5SmallR20_Calib_Algo",
-                          "m_outContainerName"        : "SelFatJets",
-                          "m_outputAlgo"              : "SelFatJets_Algo",
-                          "m_decorateSelectedObjects" : False,
-                          "m_createSelectedContainer" : True,  
-                          "m_cleanJets"               : True,
-                          "m_pT_min"                  : 200e3,
-                          "m_eta_max"                 : 2.0,
-                          "m_mass_min"                : 0.1, 
-                          "m_useCutFlow"              : True,
-                        } )
+# Small-radius jet calibrator
+c.setalg("JetCalibrator", defaults["JetCalibrator"])
 
-c.setalg("JetCalibrator", { "m_name"                  : "JetCalibrator",
-                            "m_inContainerName"       : "AntiKt4EMTopoJets",
-                            "m_jetAlgo"               : "AntiKt4EMTopo",
-                            "m_outContainerName"      : "CalibJets",
-                            "m_outputAlgo"            : "AntiKt4EMTopo_Calib_Algo",
-                            "m_debug"                 : False,
-                            "m_verbose"               : False,
-                            "m_sort"                  : True,
-                            "m_saveAllCleanDecisions" : True,
-                            "m_jetCleanCutLevel"      : "LooseBad",
-                            "m_jetCleanUgly"          : True,
-                            "m_calibConfigFullSim"    : "JES_data2016_data2015_Recommendation_Dec2016.config",
-                            "m_calibConfigData"       : "JES_data2016_data2015_Recommendation_Dec2016.config",
-                            "m_calibSequence"         : jet_calibSeq,
-                            "m_setAFII"               : False,
-                            "m_JESUncertConfig"       : "JES_2016/Moriond2017/JES2016_SR_Scenario1.config",
-                            "m_JESUncertMCType"       : "MC15",
-                            "m_JERUncertConfig"       : "JetResolution/Prerec2015_xCalib_2012JER_ReducedTo9NP_Plots_v2.root",
-                            "m_JERFullSys"            : False,
-                            "m_JERApplyNominal"       : False,
-                            "m_redoJVT"               : False,
-                            "m_systName"              : "All",
-                            "m_systVal"               : 1
-                          } )
+# Small-radius jet selector
+c.setalg("JetSelector", defaults["JetSelector"])
 
-c.setalg("JetSelector", { "m_name"                    : "JetSelector",
-                          "m_inContainerName"         : "CalibJets",
-                          "m_inputAlgo"               : "AntiKt4EMTopo_Calib_Algo",
-                          "m_outContainerName"        : "SelJets",
-                          "m_outputAlgo"              : "SelJets_Algo",
-                          "m_decorateSelectedObjects" : False,
-                          "m_createSelectedContainer" : True,
-                          "m_cleanJets"               : True,
-                          "m_pT_min"                  : 20e3,
-                          "m_eta_max"                 : 2.4,
-                          "m_pass_min"                : 0,
-                          "m_useCutFlow"              : True,
-                          "m_doBTagCut"               : False,
-                          "m_doJVT"                   : True,
-                          "m_pt_max_JVT"              : 60e3,
-                          "m_eta_max_JVT"             : 2.4,
-                          "m_JVTCut"                  : 0.59
-                        } )
-
-c.setalg("dijetISR_DAODtoMT", { "m_doJets"               : True,
-                                "m_doPhotons"            : False,
-                                "m_fatJetContainerName"  : "SelFatJets",
-                                "m_jetContainerName"     : "SelJets",
-                                "m_eventInfoDetailStr"   : "pileup truth",
-                                "m_trigDetailStr"        : "passTriggers",
-                                "m_fatJetDetailStr"      : "kinematic substructure",
-                                "m_jetDetailStr"         : "kinematic",
-                              } )
+# Dijet + ISR analysis algorithm
+dijetISR_DAODtoMT = defaults["dijetISR_DAODtoMT"]
+dijetISR_DAODtoMT["m_doJets"] = True
+c.setalg("dijetISR_DAODtoMT", dijetISR_DAODtoMT)

--- a/scripts/config_DAODtoMT_photon.py
+++ b/scripts/config_DAODtoMT_photon.py
@@ -26,7 +26,7 @@ BasicEventSelection = defaults["BasicEventSelection"]
 BasicEventSelection["m_triggerSelection"] = triggers
 c.setalg("BasicEventSelection", BasicEventSelection)
 
-# Large-radius jet calibrator # @TODO: Make common for ISR jet and photon?
+# Large-radius jet calibrator
 c.setalg("JetCalibrator", defaults["FatJetCalibrator"])
 
 # Large-radius jet selector
@@ -43,112 +43,6 @@ c.setalg("PhotonSelector", defaults["PhotonSelector"])
 
 # Dijet + ISR analysis algorithm
 dijetISR_DAODtoMT = defaults["dijetISR_DAODtoMT"]
-dijetISR_DAODtoMT["m_doPhotons"]           = True
-dijetISR_DAODtoMT["m_photonContainerName"] = "SelPhotons"
-dijetISR_DAODtoMT["m_photonDetailStr"]     = "kinematic"
+dijetISR_DAODtoMT["m_doPhotons"] = True
 c.setalg("dijetISR_DAODtoMT", dijetISR_DAODtoMT)
 
-
-
-""" Reference.
-# Basic event selection
-c.setalg("BasicEventSelection", { "m_name"                  : "BasicEventSelection",
-                                  "m_debug"                 : False,
-                                  "m_derivationName"        : deriv,
-                                  "m_applyGRLCut"           : False,
-                                  "m_doPUreweighting"       : True, # False, -- depends on PhotonCalibrator
-                                  "m_vertexContainerName"   : "PrimaryVertices",
-                                  "m_PVNTrack"              : 2,
-                                  "m_applyPrimaryVertexCut" : True,
-                                  "m_applyEventCleaningCut" : True,
-                                  "m_applyCoreFlagsCut"     : True,
-                                  "m_triggerSelection"      : triggers,
-                                  "m_storeTrigDecisions"    : True,
-                                  "m_applyTriggerCut"       : False,
-                                  "m_useMetaData"           : True,
-                                  "m_isMC"                  : args.is_MC, # @asogaard
-                                } )
-
-# Large-radius jet calibrator # @TODO: Make common for ISR jet and photon?
-c.setalg("JetCalibrator", { "m_name"                  : "FatJetCalibrator",
-                            "m_inContainerName"       : "AntiKt10LCTopoTrimmedPtFrac5SmallR20Jets",
-                            "m_jetAlgo"               : "AntiKt10LCTopoTrimmedPtFrac5SmallR20",
-                            "m_outputAlgo"            : "AntiKt10LCTopoTrimmedPtFrac5SmallR20_Calib_Algo",
-                            "m_outContainerName"      : "CalibFatJets",
-                            "m_debug"                 : False,
-                            "m_verbose"               : False,
-                            "m_sort"                  : True,
-                            "m_saveAllCleanDecisions" : True,
-                            "m_jetCleanCutLevel"      : "LooseBad",
-                            "m_jetCleanUgly"          : True,
-                            "m_cleanParent"           : True,
-                            "m_applyFatJetPreSel"     : True,
-                            "m_calibConfigFullSim"    : "JES_MC15recommendation_FatJet_Nov2016_QCDCombinationUncorrelatedWeights.config",
-                            "m_calibConfigData"       : "JES_MC15recommendation_FatJet_Nov2016_QCDCombinationUncorrelatedWeights.config",
-                            #"m_doCleaning"            : False,
-                            "m_calibSequence"         : "EtaJES_JMS",
-                            "m_JESUncertConfig"       : "UJ_2016/Moriond2017/UJ2016_CombinedMass_medium.config",
-                            "m_JESUncertMCType"       : "MC15c",
-                            "m_setAFII"               : False,
-                            "m_systName"              : systName,
-                            "m_systVal"               : systVal,
-                          } )
-
-# Large-radius jet selector # @TODO: Make common for ISR jet and photon?
-c.setalg("JetSelector", { "m_name"                    : "FatJetSelector",
-                          "m_inContainerName"         : "CalibFatJets",
-                          "m_inputAlgo"               : "AntiKt10LCTopoTrimmedPtFrac5SmallR20_Calib_Algo",
-                          "m_outContainerName"        : "SelFatJets",
-                          "m_outputAlgo"              : "SelFatJets_Algo",
-                          "m_decorateSelectedObjects" : False,
-                          "m_createSelectedContainer" : True,  
-                          "m_cleanJets"               : True,
-                          "m_pT_min"                  : 100e3,
-                          "m_eta_max"                 : 3.0,
-                          "m_mass_min"                : 0.1, 
-                          "m_useCutFlow"              : True,
-                        } )
-
-# Photon calibrator
-c.setalg("PhotonCalibrator", { "m_name"                    : "PhotonCalibrator",
-                               "m_inContainerName"         : "Photons",
-                               "m_outContainerName"        : "CalibPhotons",
-                               "m_outputAlgoSystNames"     : "Photons_Calib_Algo",
-                               "m_esModel"                 : "es2015cPRE", # @TODO: Update
-                               "m_decorrelationModel"      : "1NP_v1", # @TODO: Update
-                               "m_useAFII"                 : False,
-                               "m_systName"                : systName,
-                               "m_systVal"                 : systVal,
-                               "m_sort"                    : True,
-                               "m_randomRunNumber"         : 123456, # @TODO: Update
-                              } )
-
-# Photon selector
-c.setalg("PhotonSelector", { "m_name"                    : "PhotonsSelector",
-                             "m_inContainerName"         : "CalibPhotons",
-                             "m_inputAlgoSystNames"      : "Photons_Calib_Algo",
-                             "m_outContainerName"        : "SelPhotons",
-                             "m_outputAlgoSystNames"     : "SelPhotons_Algo",
-                             "m_decorateSelectedObjects" : False,
-                             "m_createSelectedContainer" : True,
-                             "m_pass_min"                : 0,
-                             "m_pT_min"                  : 100e3,
-                             "m_eta_max"                 : 2.37,
-                             "m_vetoCrack"               : True,
-                             "m_doAuthorCut"             : True,
-                             "m_doOQCut"                 : True,
-                             "m_photonIdCut"             : "Tight", # @TODO: Want to propagate loose as well?
-                             "m_MinIsoWPCut"             : "FixedCutTightCaloOnly"
-                           } )
-
-# Dijet + ISR analysis algorithm
-c.setalg("dijetISR_DAODtoMT", { "m_doJets"               : False,
-                                "m_doPhotons"            : True,
-                                "m_fatJetContainerName"  : "SelFatJets",
-                                "m_photonContainerName"  : "SelPhotons",
-                                "m_eventInfoDetailStr"   : "pileup truth",
-                                "m_trigDetailStr"        : "passTriggers",
-                                "m_fatJetDetailStr"      : "kinematic substructure",
-                                "m_photonDetailStr"      : "kinematic"
-                              } )
-"""


### PR DESCRIPTION
Hi @laserkaplan,

I have switched the ISR jet config to use the common definitions (was only ISR photon before). Have validated in same way as for the previous pull request -- nothing seems to break. Have cleaned up the ISR photon config to use loose ID and isolation working points (allowing for fake rate estimation, should it come up) and updated according to the latest (Moriond 2017) recommendations for photon systematics.

Let me know if there's anything unclear in the request.

Cheers,
A.